### PR TITLE
fix setuptools warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,8 @@ testing = ["pytest"]
 [project.scripts]
 pykdebugparser = "pykdebugparser.__main__:cli"
 
-
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools.packages.find]
+exclude = ["tests*"]
 
 [tool.setuptools.package-data]
 pykdebugparser = ["*.txt", "*.TXT", "*.codes"]


### PR DESCRIPTION
the pyproject configuration installed the tests folder and a QA issue has been raised on Pentoo overlay when installing and doing tests. this little fix solves that by excluding the tests folder.

also solve the warning for licence file. I'm not sure about the bdist_whell tho.